### PR TITLE
Resolve fix in windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,10 +5,12 @@ export default function generateAliasesResolver(aliasesToAdd) {
 
     const base = process.cwd();
 
+    const windowsSupportString = process.platform === 'win32' ? 'file://' : ''
+
     const absoluteAliases = Object.keys(aliasesToAdd).reduce((acc, key) =>
       aliasesToAdd[key][0] === '/'
         ? acc
-        : { ...acc, [key]: path.join(base, aliasesToAdd[key]) },
+        : { ...acc, [key]: path.join(windowsSupportString, base, aliasesToAdd[key]) },
       aliasesToAdd)
 
     return absoluteAliases;


### PR DESCRIPTION
Prevents this error

```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'e:'
    at new NodeError (node:internal/errors:377:5)
    at throwIfUnsupportedURLScheme (node:internal/modules/esm/resolve:1076:11)
    at defaultResolve (node:internal/modules/esm/resolve:1156:3)
    at file:///E:/Projects/ikl/node_modules/esm-module-alias/index.js:33:12
    at ESMLoader.resolve (node:internal/modules/esm/loader:605:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:318:18)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:80:40)
    at link (node:internal/modules/esm/module_job:78:36) {
  code: 'ERR_UNSUPPORTED_ESM_URL_SCHEME'
}
```